### PR TITLE
Removed hyphens from profile widget ID's

### DIFF
--- a/includes/footer.twig
+++ b/includes/footer.twig
@@ -8,13 +8,13 @@
 				{{widget('content', 'footer-content-contact-left', {
 					content: '<p>Current information tailored to your interests.</p>'
 				})|raw}}
-				{{widget('profile', 'footer-profile-contact-left', {'profileType':'form'})|raw}}
+				{{widget('profile', 'footerprofilecontactleft', {'profileType':'form'})|raw}}
 			</div>
 			<div class="footer--contact-right">
 				{{widget('content', 'footer-content-contact-right', {
 					content: '<p>Velocity on Social Media</p>'
 				})|raw}}
-				{{widget('profile', 'footer-profile-contact-right', {'profileType':'socialicons'})|raw}}
+				{{widget('profile', 'footerprofilecontactright', {'profileType':'socialicons'})|raw}}
 			</div>
 		</div>
 		<div class="footer--information">


### PR DESCRIPTION
Hey Eva i'm not sure if this will solve the issue but could we try removing the hyphens from the widget ID's where the profile widget is used. I will keep an eye on your environment to make sure this change is applied and if it still isn't resolved I will raise this back to the development team.